### PR TITLE
Fix passing a bash argument in the shebang

### DIFF
--- a/app/update_jruby_jar.sh
+++ b/app/update_jruby_jar.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set +e
 
 VERSION="9.2.9.0"
 # FULL_VERSION="${VERSION}"


### PR DESCRIPTION
The current shebang results in the following error in some `env` implementations.

```
/usr/bin/env: ‘bash -e’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

This commit fixes that.